### PR TITLE
Config splats were fucked on 1.9

### DIFF
--- a/lib/cijoe/config.rb
+++ b/lib/cijoe/config.rb
@@ -1,7 +1,7 @@
 class CIJoe
   class Config
     def self.method_missing(command, *args)
-      new(command, args)
+      new(command, *args)
     end
 
     def initialize(command, project_path = nil, parent = nil)


### PR DESCRIPTION
...and now they're not. Tested in production.
