### PR TITLE
Change waitpid to waitpid with an argument of 1

### DIFF
--- a/lib/cijoe.rb
+++ b/lib/cijoe.rb
@@ -137,7 +137,7 @@ class CIJoe
       output = pipe.read
     end
 
-    Process.waitpid(build.pid)
+    Process.waitpid(build.pid, 1)
     status = $?.exitstatus.to_i
     puts "#{Time.now.to_i}: Built #{build.short_sha}: status=#{status}"
 

--- a/lib/cijoe/campfire.rb
+++ b/lib/cijoe/campfire.rb
@@ -15,8 +15,7 @@ class CIJoe
         puts "Can't load Campfire notifier."
         puts "Please add the following to your project's .git/config:"
         puts "[campfire]"
-        puts "\tuser = your@campfire.email"
-        puts "\tpass = passw0rd"
+        puts "\ttoken = your_api_token"
         puts "\tsubdomain = whatever"
         puts "\troom = Awesomeness"
         puts "\tssl = false"
@@ -26,16 +25,15 @@ class CIJoe
     def self.config
       campfire_config = Config.new('campfire', @project_path)
       @config ||= {
-        :subdomain => campfire_config.subdomain.to_s,
-        :user      => campfire_config.user.to_s,
-        :pass      => campfire_config.pass.to_s,
-        :room      => campfire_config.room.to_s,
-        :ssl       => campfire_config.ssl.to_s.strip == 'true'
+        :subdomain => Config.campfire.subdomain.to_s,
+        :token     => Config.campfire.token.to_s,
+        :room      => Config.campfire.room.to_s,
+        :ssl       => Config.campfire.ssl.to_s.strip == 'true'
       }
     end
 
     def self.valid_config?
-      %w( subdomain user pass room ).all? do |key|
+      %w( subdomain token room ).all? do |key|
         !config[key.intern].empty?
       end
     end
@@ -51,8 +49,7 @@ class CIJoe
       @room ||= begin
         config = Campfire.config
         campfire = Tinder::Campfire.new(config[:subdomain],
-            :username => config[:user],
-            :password => config[:pass],
+            :token => config[:token],
             :ssl => config[:ssl] || false)
         campfire.find_room_by_name(config[:room])
       end

--- a/lib/cijoe/campfire.rb
+++ b/lib/cijoe/campfire.rb
@@ -25,10 +25,10 @@ class CIJoe
     def self.config
       campfire_config = Config.new('campfire', @project_path)
       @config ||= {
-        :subdomain => Config.campfire.subdomain.to_s,
-        :token     => Config.campfire.token.to_s,
-        :room      => Config.campfire.room.to_s,
-        :ssl       => Config.campfire.ssl.to_s.strip == 'true'
+        :subdomain => campfire_config.subdomain.to_s,
+        :token     => campfire_config.token.to_s,
+        :room      => campfire_config.room.to_s,
+        :ssl       => campfire_config.ssl.to_s.strip == 'true'
       }
     end
 


### PR DESCRIPTION
Hi Chris,

I'm building a small front end to manage multiple cijoes here: https://github.com/gotascii/duke I'm using daemon_controller and nohup to spin off cijoe daemons and keep track of their start/stop states. In building the gem I ran into a problem where a process returning and exit status of 1 wasn't showing up as a failure. I traced this to the fact that the default flag for waitpid is 0 which according to the docs means that it "Waits for any child whose process group ID equals that of the calling process." Based on the way I am spinning up cijoes the $?.exitstatus wasn't the exit status of the pid argument to waitpid. I changed the flag to 1 which means "Waits for the child whose process ID equals pid." This solves my problem by explicitly waiting for the process who's exitstatus cijoe cares about. The tests all pass and according to the docs waitpid should function the same in 1.8.7 and 1.9.2. Let me know if I can provide further explanation or help in any way to get this into master. Thanks!

Justin
