### PR TITLE
displaying branch name

### DIFF
--- a/lib/cijoe.rb
+++ b/lib/cijoe.rb
@@ -124,13 +124,14 @@ class CIJoe
   def build!(branch=nil)
     @git_branch = branch
     build = @current_build
+    @current_build.branch = git_branch
     output = ''
     git_update
     build.sha = git_sha
     write_build 'current', build
 
     open_pipe("cd #{@project_path} && #{runner_command} 2>&1") do |pipe, pid|
-      puts "#{Time.now.to_i}: Building #{build.short_sha}: pid=#{pid}"
+      puts "#{Time.now.to_i}: Building #{build.branch} at #{build.short_sha}: pid=#{pid}"
 
       build.pid = pid
       write_build 'current', build

--- a/lib/cijoe.rb
+++ b/lib/cijoe.rb
@@ -124,10 +124,10 @@ class CIJoe
   def build!(branch=nil)
     @git_branch = branch
     build = @current_build
-    @current_build.branch = git_branch
     output = ''
     git_update
     build.sha = git_sha
+    build.branch = git_branch
     write_build 'current', build
 
     open_pipe("cd #{@project_path} && #{runner_command} 2>&1") do |pipe, pid|

--- a/lib/cijoe/build.rb
+++ b/lib/cijoe/build.rb
@@ -1,7 +1,7 @@
 require 'yaml'
 
 class CIJoe
-  class Build < Struct.new(:project_path, :user, :project, :started_at, :finished_at, :sha, :status, :output, :pid)
+  class Build < Struct.new(:project_path, :user, :project, :started_at, :finished_at, :sha, :status, :output, :pid, :branch)
     def initialize(*args)
       super
       self.started_at ||= Time.now

--- a/lib/cijoe/build.rb
+++ b/lib/cijoe/build.rb
@@ -52,7 +52,7 @@ class CIJoe
     end
 
     def dump(file)
-      config = [user, project, started_at, finished_at, sha, status, output, pid]
+      config = [user, project, started_at, finished_at, sha, status, output, pid, branch]
       data = YAML.dump(config)
       File.open(file, 'wb') { |io| io.write(data) }
     end

--- a/lib/cijoe/version.rb
+++ b/lib/cijoe/version.rb
@@ -1,3 +1,3 @@
 class CIJoe
-  Version = VERSION = "0.5.0"
+  Version = VERSION = "0.7.2"
 end

--- a/lib/cijoe/views/template.erb
+++ b/lib/cijoe/views/template.erb
@@ -19,7 +19,7 @@
             <li>
               <span class="date"><%= pretty_time(joe.current_build.started_at) if joe.current_build %></span> &raquo;
               <% if joe.current_build.sha %>
-                Building <a href="<%= joe.current_build.commit.url %>"><%= joe.current_build.short_sha %></a> <small>(pid: <%= joe.pid %>)</small>
+                Building <%= joe.current_build.branch %> at <a href="<%= joe.current_build.commit.url %>"><%= joe.current_build.short_sha %></a> <small>(pid: <%= joe.pid %>)</small>
               <% else %>
                 Build starting...
               <% end %>
@@ -32,7 +32,7 @@
             <li>
               <span class="date"><%= pretty_time(joe.last_build.finished_at) %></span> &raquo;
               <% if joe.last_build.sha %>
-                Built <a href="<%= joe.last_build.commit.url %>"><%= joe.last_build.short_sha %></a>
+                Built <%= joe.current_build.branch %> at <a href="<%= joe.last_build.commit.url %>"><%= joe.last_build.short_sha %></a>
               <% end %>
               <span class="<%= joe.last_build.status %>">(<%= joe.last_build.status %>)</span>
               <% if joe.last_build.duration %>

--- a/lib/cijoe/views/template.erb
+++ b/lib/cijoe/views/template.erb
@@ -32,7 +32,7 @@
             <li>
               <span class="date"><%= pretty_time(joe.last_build.finished_at) %></span> &raquo;
               <% if joe.last_build.sha %>
-                Built <%= joe.current_build.branch %> at <a href="<%= joe.last_build.commit.url %>"><%= joe.last_build.short_sha %></a>
+                Built <%= joe.last_build.branch %> at <a href="<%= joe.last_build.commit.url %>"><%= joe.last_build.short_sha %></a>
               <% end %>
               <span class="<%= joe.last_build.status %>">(<%= joe.last_build.status %>)</span>
               <% if joe.last_build.duration %>


### PR DESCRIPTION
I looked at the last addition to make the branch selectable and really liked it. I found the information, what branch has been build missing, so I added it.

I'd much appreciate it, if you'd pull it into master and bumped the gem version, so gem update get's us the new one in production.

Cheers
Chris
