### PR TITLE
Rescue from YAML and fix build status.

### DIFF
--- a/lib/cijoe.rb
+++ b/lib/cijoe.rb
@@ -139,6 +139,7 @@ class CIJoe
 
     Process.waitpid(build.pid, 1)
     status = $?.exitstatus.to_i
+    @current_build = build
     puts "#{Time.now.to_i}: Built #{build.short_sha}: status=#{status}"
 
     status == 0 ? build_worked(output) : build_failed('', output)

--- a/lib/cijoe/server.rb
+++ b/lib/cijoe/server.rb
@@ -27,7 +27,7 @@ class CIJoe
     end
 
     post '/?' do
-      payload = YAML.load(params[:payload].to_s) rescue { }
+      payload = YAML.load(params[:payload].to_s) || {}
       pushed_branch = payload['ref'].to_s.split('/').last
 
       # Only build if we were given an explicit branch via `?branch=blah`,

--- a/lib/cijoe/server.rb
+++ b/lib/cijoe/server.rb
@@ -27,7 +27,7 @@ class CIJoe
     end
 
     post '/?' do
-      payload = YAML.load(params[:payload].to_s) || {}
+      payload = YAML.load(params[:payload].to_s) rescue { }
       pushed_branch = payload['ref'].to_s.split('/').last
 
       # Only build if we were given an explicit branch via `?branch=blah`,


### PR DESCRIPTION
Rescue from YAML: In Ruby 1.9.2 YAML will fail with `ArgumentError: syntax error on line 0, col 132` when it receives the Github post-receive POST. This should fix it.

I also noticed that the build fields are updated in `CIJoe#build!` in an instance variable but they're never assigned back to `@current_build`. Stuff like the Campfire notifier needs this information to post the log in the chat so I just copied it back.
