### PR TITLE
Copy build status in CIJoe#build!

### DIFF
--- a/lib/cijoe.rb
+++ b/lib/cijoe.rb
@@ -139,6 +139,7 @@ class CIJoe
 
     Process.waitpid(build.pid, 1)
     status = $?.exitstatus.to_i
+    @current_build = build
     puts "#{Time.now.to_i}: Built #{build.short_sha}: status=#{status}"
 
     status == 0 ? build_worked(output) : build_failed('', output)


### PR DESCRIPTION
I also noticed that the build fields are updated in CIJoe#build! in an instance variable but they're never assigned back to @current_build. Stuff like the Campfire notifier needs this information to post the log in the chat so I just copied it back.
