### PR TITLE
Fix YAML errors

### DIFF
--- a/lib/cijoe/server.rb
+++ b/lib/cijoe/server.rb
@@ -27,7 +27,8 @@ class CIJoe
     end
 
     post '/?' do
-      payload = YAML.load(params[:payload].to_s) || {}
+      payload = YAML.load(params[:payload].to_s) rescue { }
+      payload ||= { }
       pushed_branch = payload['ref'].to_s.split('/').last
 
       # Only build if we were given an explicit branch via `?branch=blah`,


### PR DESCRIPTION
- In Ruby 1.8.7 and 1.9.2 YAML will fail with `ArgumentError` when it receives the Github post-receive POST. This should fix it.
