### PR TITLE
Fix the post method to properly decode the json

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ Campfire notification is included, because it's what we use. Want Joe
 notify your Campfire? Put this in your repo's `.git/config`:
 
     [campfire]
-    	user = your@campfire.email
-    	pass = passw0rd
+    	token = abcd1234
     	subdomain = whatever
     	room = Awesomeness
     	ssl = false
@@ -86,7 +85,7 @@ notify your Campfire? Put this in your repo's `.git/config`:
 Or do it the old fashion way:
 
     $ cd yourrepo
-    $ git config --add campfire.user chris@ozmm.org
+    $ git config --add campfire.token abcd1234
     $ git config --add campfire.subdomain github
     etc.
 

--- a/cijoe.gemspec
+++ b/cijoe.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency     'choice'
   s.add_runtime_dependency     'sinatra'
+  s.add_runtime_dependency     'json'
   s.add_development_dependency 'rack-test'
 
    s.description       = <<desc

--- a/lib/cijoe.rb
+++ b/lib/cijoe.rb
@@ -79,7 +79,7 @@ class CIJoe
     @current_build = nil
     write_build 'current', @current_build
     write_build 'last', @last_build
-    @campfire.notify if @campfire.valid?
+    @campfire.notify(@last_build) if @campfire.valid?
 
     # another build waits
     if !repo_config.buildallfile.to_s.empty? && File.exist?(repo_config.buildallfile.to_s)

--- a/lib/cijoe.rb
+++ b/lib/cijoe.rb
@@ -21,13 +21,15 @@ require 'cijoe/campfire'
 require 'cijoe/server'
 
 class CIJoe
-  attr_reader :user, :project, :url, :current_build, :last_build
+  attr_reader :user, :project, :url, :current_build, :last_build, :campfire
 
   def initialize(project_path)
     @project_path = File.expand_path(project_path)
 
     @user, @project = git_user_and_project
     @url = "http://github.com/#{@user}/#{@project}"
+
+    @campfire = CIJoe::Campfire.new(project_path)
 
     @last_build = nil
     @current_build = nil
@@ -77,7 +79,7 @@ class CIJoe
     @current_build = nil
     write_build 'current', @current_build
     write_build 'last', @last_build
-    @last_build.notify if @last_build.respond_to? :notify
+    @campfire.notify if @campfire.valid?
 
     # another build waits
     if !repo_config.buildallfile.to_s.empty? && File.exist?(repo_config.buildallfile.to_s)

--- a/lib/cijoe/campfire.rb
+++ b/lib/cijoe/campfire.rb
@@ -1,6 +1,6 @@
 class CIJoe
   class Campfire
-    attr_reader :project_path
+    attr_reader :project_path, :build
     
     def initialize(project_path)
       @project_path = project_path
@@ -34,10 +34,11 @@ class CIJoe
       end
     end
 
-    def notify
+    def notify(build)
       begin
-        room.speak "#{short_message}. #{commit.url}"
-        room.paste full_message if failed?
+        @build = build
+        room.speak "#{short_message}. #{build.commit.url}"
+        room.paste full_message if build.failed?
         room.leave
       rescue
         puts "Please check your campfire config for #{project_path}."
@@ -56,17 +57,17 @@ class CIJoe
     end
 
     def short_message
-      "#{branch} at #{short_sha} of #{project} " +
-        (worked? ? "passed" : "failed") + " (#{duration.to_i}s)"
+      "#{build.branch} at #{build.short_sha} of #{build.project} " +
+        (build.worked? ? "passed" : "failed") + " (#{build.duration.to_i}s)"
     end
 
     def full_message
       <<-EOM
-Commit Message: #{commit.message}
-Commit Date: #{commit.committed_at}
-Commit Author: #{commit.author}
+Commit Message: #{build.commit.message}
+Commit Date: #{build.commit.committed_at}
+Commit Author: #{build.commit.author}
 
-#{clean_output}
+#{build.clean_output}
 EOM
     end
   end

--- a/lib/cijoe/server.rb
+++ b/lib/cijoe/server.rb
@@ -1,5 +1,6 @@
 require 'sinatra/base'
 require 'erb'
+require 'json'
 
 class CIJoe
   class Server < Sinatra::Base
@@ -27,15 +28,15 @@ class CIJoe
     end
 
     post '/?' do
-      payload = params[:payload].to_s
-      if payload =~ /"ref":"(.+?)"/
-        pushed_branch = $1.split('/').last
+      unless params[:rebuild]
+        payload = JSON.parse(params[:payload])
+        pushed_branch = payload["ref"].split('/').last
       end
-
-      # Only build if we were given an explicit branch via `?branch=blah`,
-      # no payload exists (we're probably testing), or the payload exists and
-      # the "ref" property matches our specified build branch.
-      if params[:branch] || payload.empty? || pushed_branch == joe.git_branch
+      
+      # Only build if we were given an explicit branch via `?branch=blah`
+      # or the payload exists and the "ref" property matches our 
+      # specified build branch.
+      if params[:branch] || params[:rebuild] || pushed_branch == joe.git_branch
         joe.build(params[:branch])
       end
 

--- a/lib/cijoe/server.rb
+++ b/lib/cijoe/server.rb
@@ -80,8 +80,6 @@ class CIJoe
       super
       check_project
       @joe = CIJoe.new(options.project_path)
-
-      CIJoe::Campfire.activate(options.project_path)
     end
 
     def self.start(host, port, project_path)

--- a/lib/cijoe/version.rb
+++ b/lib/cijoe/version.rb
@@ -1,3 +1,3 @@
 class CIJoe
-  Version = VERSION = "0.9.1"
+  Version = VERSION = "0.9.2"
 end

--- a/lib/cijoe/views/json.erb
+++ b/lib/cijoe/views/json.erb
@@ -2,7 +2,15 @@
 <% if joe.last_build %>
 {"name":"<%= joe.project %>",
  "url":"<%= joe.url %>",
- "color":"<%= joe.last_build.status.to_s == "failed" ? 'red' : 'blue' %>"
+ "color":"<%= joe.last_build.status.to_s == "failed" ? 'red' : 'blue' %>",
+ "status":"<%= joe.last_build.status %>",
+ "started_at":"<%= pretty_time(joe.last_build.started_at) %>",
+ "finished_at":"<%= pretty_time(joe.last_build.finished_at) %>",
+ "duration":"<%= joe.last_build.duration if joe.last_build.duration %>",
+ "sha":"<%= joe.last_build.sha %>",
+ "short_sha":"<%= joe.last_build.short_sha %>",
+ "commit_url":"<%= joe.last_build.commit.url if joe.last_build.commit %>",
+ "branch":"<%= joe.last_build.branch %>"
  }
 <% end %>
 ]}

--- a/lib/cijoe/views/template.erb
+++ b/lib/cijoe/views/template.erb
@@ -25,7 +25,7 @@
               <% end %>
             </li>
           <% else %>
-            <li><form method="POST"><input type="submit" value="Build"/></form></li>
+            <li><form method="POST"><input type="hidden", name="rebuild" value="true"><input type="submit" value="Build"/></form></li>
           <% end %>
           
           <% if joe.last_build %>

--- a/test/fixtures/payload.json
+++ b/test/fixtures/payload.json
@@ -1,0 +1,52 @@
+{
+    "after": "416cb2f7105e7f989bc223d1a975b93a6491b276",
+    "before": "0ae4da1eea2d191b33ebfbd5db48e3c1f91953ad",
+    "commits": [
+        {
+            "added": [
+                
+            ],
+            "author": {
+                "email": "joshua.owens@gmail.com",
+                "name": "Josh Owens",
+                "username": "queso" 
+            },
+            "id": "09293a1703b3bdb36aba70d38abd5e44396c50a5",
+            "message": "Update README",
+            "modified": [
+                "README.textile" 
+            ],
+            "removed": [
+                
+            ],
+            "timestamp": "2011-02-07T15:27:35-08:00",
+            "url": "https:\/\/github.com\/fourbeansoup\/broth\/commit\/09293a1703b3bdb36aba70d38abd5e44396c50a5" 
+        } 
+    ],
+    "compare": "https:\/\/github.com\/fourbeansoup\/broth\/compare\/0ae4da1...416cb2f",
+    "forced": false,
+    "ref": "refs\/heads\/master",
+    "repository": {
+        "created_at": "2009\/12\/05 10:44:57 -0800",
+        "description": "FourBeanSoup's Broth Application, a tasty starting point for every app",
+        "fork": true,
+        "forks": 4,
+        "has_downloads": true,
+        "has_issues": true,
+        "has_wiki": true,
+        "homepage": "",
+        "language": "JavaScript",
+        "name": "broth",
+        "open_issues": 2,
+        "organization": "fourbeansoup",
+        "owner": {
+            "email": "josh+scm@fourbeansoup.com",
+            "name": "fourbeansoup" 
+        },
+        "private": false,
+        "pushed_at": "2011\/02\/07 17:17:00 -0800",
+        "size": 604,
+        "url": "https:\/\/github.com\/fourbeansoup\/broth",
+        "watchers": 10 
+    }
+}

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,5 +10,37 @@ require 'cijoe'
 CIJoe::Server.set :project_path, "."
 CIJoe::Server.set :environment,  "test"
 
+TMP_DIR = '/tmp/cijoe_test'
+
+def tmp_dir
+  TMP_DIR
+end
+
+def setup_git_info(options = {})
+  @tmp_dirs ||= []
+  @tmp_dirs += [options[:tmp_dir]]
+  create_tmpdir!(options[:tmp_dir])
+  dir = options[:tmp_dir] || tmp_dir
+  `cd #{dir} && git init`
+  options[:config].each do |key, value|
+    `cd #{dir} && git config --add #{key} "#{value}"`
+  end
+end
+
+def teardown_git_info
+  remove_tmpdir!
+  @tmp_dirs.each do |dir|
+    remove_tmpdir!(dir)
+  end
+end
+
+def remove_tmpdir!(passed_dir = nil)
+  FileUtils.rm_rf(passed_dir || tmp_dir)
+end
+
+def create_tmpdir!(passed_dir = nil)
+  FileUtils.mkdir_p(passed_dir || tmp_dir)
+end
+
 class Test::Unit::TestCase
 end

--- a/test/test_campfire.rb
+++ b/test/test_campfire.rb
@@ -1,0 +1,48 @@
+require "helper"
+require "cijoe"
+require "fakefs/safe"
+
+
+class TestCampfire < Test::Unit::TestCase
+
+  class ::CIJoe
+    attr_writer :current_build, :last_build
+  end
+
+  attr_accessor :app
+
+  def setup
+    @app = CIJoe::Server.new
+    joe = @app.joe
+    
+    # make Build#restore a no-op so we don't overwrite our current/last
+    # build attributes set from tests.
+    def joe.restore
+    end
+    
+    # make CIJoe#build! and CIJoe#git_update a no-op so we don't overwrite our local changes
+    # or local commits nor should we run tests.
+    def joe.build!
+    end
+  end
+  
+  def teardown
+    teardown_git_info
+  end
+  
+  def test_campfire_pulls_campfire_config_from_git_config
+    setup_git_info(:config => {"campfire.subdomain" => "github", "remote.origin.url" => "https://github.com/defunkt/cijoe.git"})
+    cf = CIJoe::Campfire.new(tmp_dir)
+    assert_equal "github", cf.campfire_config[:subdomain]
+  end
+  
+  def test_campfire_pulls_campfire_config_from_its_own_git_config
+    setup_git_info(:config => {"campfire.subdomain" => "github"})
+    setup_git_info(:config => {"campfire.subdomain" => "37signals"}, :tmp_dir => "/tmp/cijoe_test_37signals")
+    cf1 = CIJoe::Campfire.new(tmp_dir)
+    cf2 = CIJoe::Campfire.new("/tmp/cijoe_test_37signals")
+    assert_equal "github", cf1.campfire_config[:subdomain]
+    assert_equal "37signals", cf2.campfire_config[:subdomain]
+  end
+  
+end

--- a/test/test_cijoe_server.rb
+++ b/test/test_cijoe_server.rb
@@ -13,10 +13,16 @@ class TestCIJoeServer < Test::Unit::TestCase
 
   def setup
     @app = CIJoe::Server.new
+    joe = @app.joe
+    
     # make Build#restore a no-op so we don't overwrite our current/last
     # build attributes set from tests.
-    joe = @app.joe
     def joe.restore
+    end
+    
+    # make CIJoe#build! and CIJoe#git_update a no-op so we don't overwrite our local changes
+    # or local commits nor should we run tests.
+    def joe.build!
     end
   end
 
@@ -64,6 +70,30 @@ class TestCIJoeServer < Test::Unit::TestCase
     assert_equal current_build, app.joe.current_build
   end
 
+  def test_post_with_json_works
+    post '/', :payload => File.read("#{Dir.pwd}/test/fixtures/payload.json")
+    assert app.joe.building?
+    assert_equal 302, last_response.status
+  end
+  
+  def test_post_does_not_build_on_branch_mismatch
+    post "/", :payload => {"ref" => "refs/heads/dont_build"}.to_json
+    assert !app.joe.building?
+    assert_equal 302, last_response.status
+  end
+
+  def test_post_does_build_on_branch_match
+    post "/", :payload => {"ref" => "refs/heads/master"}.to_json
+    assert app.joe.building?
+    assert_equal 302, last_response.status
+  end
+  
+  def test_post_does_build_when_build_button_is_used
+    post "/", :rebuild => true
+    assert app.joe.building?
+    assert_equal 302, last_response.status
+  end
+
   def test_jsonp_should_return_plain_json_without_param
     app.joe.last_build = build :failed
     get "/api/json"
@@ -74,7 +104,6 @@ class TestCIJoeServer < Test::Unit::TestCase
   def test_jsonp_should_return_jsonp_with_param
     app.joe.last_build = build :failed
     get "/api/json?jsonp=fooberz"
-    puts last_response.inspect
     assert_equal 200, last_response.status
     assert_equal 'application/json', last_response.content_type
     assert_match /^fooberz\(/, last_response.body 


### PR DESCRIPTION
This patch includes both tests and fixes for the issue with json decoding and for clicking the build button.  The logic wrapper line 39 (joe.build) had payload.empty?, which was true every time because the payload isn't being handled right.

I added failing tests to ensure that doesn't happen again, as well as tests with actual payloads from Github.  I also had to stub out joe.build! as it kept force resetting the local git repo with the remote master.
