### PR TITLE
added tinder as dependency.

### DIFF
--- a/cijoe.gemspec
+++ b/cijoe.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency     'choice'
   s.add_runtime_dependency     'sinatra'
+  s.add_runtime_dependency     'tinder', '>= 1.4.0'
   s.add_development_dependency 'rack-test'
 
    s.description       = <<desc


### PR DESCRIPTION
this matches rip and uses at least 1.4.0 to match new Tinder API:

https://github.com/defunkt/cijoe/commit/6d4823c
