### PR TITLE
Build queue supports branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ Want joe to run against a branch other than `master`? No problem:
     $ git config --add cijoe.branch deploy
 
 
-Concurrent Push's - a kind of "queueing"
+Queueing
 ----------------------------------------
 
 Joe runs just one build at the time. If you expect concurrent push's
 to your repo and want joe to build each in a kind of queue, just set:
 
-    $ git config --add cijoe.buildallfile tmp/cijoe.txt
+    $ git config --add cijoe.buildqueue true
 
 Joe will save requests while another build runs. If more than one push
 hits joe, he just picks the last after finishing the prior.

--- a/lib/cijoe.rb
+++ b/lib/cijoe.rb
@@ -32,7 +32,7 @@ class CIJoe
 
     @last_build = nil
     @current_build = nil
-    @queue = Queue.new(!repo_config.buildqueue.empty?)
+    @queue = Queue.new(!repo_config.buildqueue.to_s.empty?, true)
 
     trap("INT") { stop }
   end

--- a/lib/cijoe/queue.rb
+++ b/lib/cijoe/queue.rb
@@ -1,0 +1,43 @@
+class CIJoe
+  # An in memory queue used for maintaining an order list of requested
+  # builds.
+  class Queue
+    # enabled - determines whether builds should be queued or not.
+    def initialize(enabled)
+      @enabled = enabled
+      @queue = []
+    end
+
+    # Public: Appends a branch to be built, unless it already exists
+    # within the queue.
+    #
+    # branch - the name of the branch to build or nil if the default
+    #         should be built.
+    #
+    # Returns nothing
+    def append_unless_already_exists(branch)
+      return unless enabled?
+      @queue << branch unless @queue.include? branch
+    end
+
+    # Returns a String of the next branch to build
+    def next_branch_to_build
+      @queue.shift
+    end
+
+    # Returns true if there are requested builds waiting and false
+    # otherwise.
+    def waiting?
+      if enabled?
+        not @queue.empty?
+      else
+        false
+      end
+    end
+
+  protected
+    def enabled?
+      @enabled
+    end
+  end
+end

--- a/lib/cijoe/queue.rb
+++ b/lib/cijoe/queue.rb
@@ -3,9 +3,12 @@ class CIJoe
   # builds.
   class Queue
     # enabled - determines whether builds should be queued or not.
-    def initialize(enabled)
+    def initialize(enabled, verbose=false)
       @enabled = enabled
+      @verbose = verbose
       @queue = []
+
+      log("Build queueing enabled") if enabled
     end
 
     # Public: Appends a branch to be built, unless it already exists
@@ -17,12 +20,17 @@ class CIJoe
     # Returns nothing
     def append_unless_already_exists(branch)
       return unless enabled?
-      @queue << branch unless @queue.include? branch
+      unless @queue.include? branch
+        @queue << branch
+        log "#{Time.now.to_i}: Queueing #{branch}"
+      end
     end
 
     # Returns a String of the next branch to build
     def next_branch_to_build
-      @queue.shift
+      branch = @queue.shift
+      log "#{Time.now.to_i}: De-queueing #{branch}"
+      branch
     end
 
     # Returns true if there are requested builds waiting and false
@@ -36,6 +44,10 @@ class CIJoe
     end
 
   protected
+    def log(msg)
+      puts msg if @verbose
+    end
+
     def enabled?
       @enabled
     end

--- a/test/test_cijoe_queue.rb
+++ b/test/test_cijoe_queue.rb
@@ -1,0 +1,28 @@
+require 'helper'
+
+class TestCIJoeQueue < Test::Unit::TestCase
+  def test_a_disabled_queue
+    subject = CIJoe::Queue.new(false)
+    subject.append_unless_already_exists("test")
+    assert_equal false, subject.waiting?
+  end
+
+  def test_adding_two_items_to_a_queue
+    subject = CIJoe::Queue.new(true)
+    subject.append_unless_already_exists("test")
+    subject.append_unless_already_exists(nil)
+    assert_equal true, subject.waiting?
+    assert_equal "test", subject.next_branch_to_build
+    assert_equal nil, subject.next_branch_to_build
+    assert_equal false, subject.waiting?
+  end
+
+  def test_adding_two_duplicate_items_to_a_queue
+    subject = CIJoe::Queue.new(true)
+    subject.append_unless_already_exists("test")
+    subject.append_unless_already_exists("test")
+    assert_equal true, subject.waiting?
+    assert_equal "test", subject.next_branch_to_build
+    assert_equal false, subject.waiting?
+  end
+end

--- a/test/test_cijoe_server.rb
+++ b/test/test_cijoe_server.rb
@@ -74,11 +74,9 @@ class TestCIJoeServer < Test::Unit::TestCase
   def test_jsonp_should_return_jsonp_with_param
     app.joe.last_build = build :failed
     get "/api/json?jsonp=fooberz"
-    puts last_response.inspect
     assert_equal 200, last_response.status
     assert_equal 'application/json', last_response.content_type
-    assert_match /^fooberz\(/, last_response.body 
-
+    assert_match /^fooberz\(/, last_response.body
   end
 
   def test_should_not_barf_when_no_build


### PR DESCRIPTION
Currently if the build queue is enabled and you queue a branch to build and another branch is currently being built, CI Joe forgets which branch you asked to build. This pull request implements a simple in memory queue to capture that information branch.

Branches are built in the order requested and if a request has already been made for a branch a second one won't be added. This branch also changes the configuration option slightly, as a file location is no longer required (an updated README is included).
