### PR TITLE
Ran into a problem with "sh" on Ubuntu 11.04 and CIJoe's "build-worked" hook...

### DIFF
--- a/lib/cijoe.rb
+++ b/lib/cijoe.rb
@@ -179,7 +179,7 @@ class CIJoe
       orig_ENV = ENV.to_hash
       ENV.clear
       data.each{ |k, v| ENV[k] = v }
-      output = `cd #{@project_path} && sh #{file}`
+      output = `cd #{@project_path} && #{file}`
       
       ENV.clear
       orig_ENV.to_hash.each{ |k, v| ENV[k] = v}


### PR DESCRIPTION
Thanks for the great utility. I'm starting to use CIJoe as a quick-start CI tool for teams that I work with. It's a great way to get them familiar with the concepts. At my current assignment, we were attempting to use CIJoe with a PHP project and defined a "build-worked" script as follows:

```
#!/usr/bin/env php
<?php

echo "Build Complete!";
```

When CIJoe attempted to run the script, it complained about a syntax error on line 2: it was attempting to pipe in a file named "?php". We removed the `sh` invocation from `CIJoe#run_hooks` and it ran cleanly. Apparently `dash` (which is invoked by `sh` on Ubuntu 11.04) wasn't reading the shebang line correctly. We changed the shebang to refer directly to the PHP executable, instead of editing the gem, and still no love.

I understand dropping into a sub-shell to execute the file, but since it's already checked as an executable script, is that necessary? Anyway, it seems to work for us. Thanks again,

David et al

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/defunkt/cijoe/69)

<!-- Reviewable:end -->
