### PR TITLE
Defining project_path stuck in recursion

### DIFF
--- a/lib/cijoe/server.rb
+++ b/lib/cijoe/server.rb
@@ -100,7 +100,7 @@ class CIJoe
         end
         puts "Using HTTP basic auth"
       end
-      set :project_path, Proc.new{project_path}
+      set :project_path, Proc.new{project_path}, true
     end
 
     def check_project


### PR DESCRIPTION
I experienced some difficulties while trying to start the cijoe server on my local machine (OS X). The set call on line `103` got stuck in recursion. This could be solved by passing the third parameter named `ignore_setter`.
