### PR TITLE
Fix bug where there's no rebuild parameter and no JSON to parse

### DIFF
--- a/lib/cijoe/server.rb
+++ b/lib/cijoe/server.rb
@@ -30,7 +30,9 @@ class CIJoe
     post '/?' do
       unless params[:rebuild]
         payload = JSON.parse(params[:payload])
-        pushed_branch = payload["ref"].split('/').last
+        unless payload["ref"].nil?
+          pushed_branch = payload["ref"].split('/').last
+        end
       end
       
       # Only build if we were given an explicit branch via `?branch=blah`


### PR DESCRIPTION
This causes a "TypeError: can't convert nil into String" when you just
try to do something like curl -X POST http://mycijoe/

See issue #65
